### PR TITLE
Fix:큐레이션 상세 스크롤 마다 해당하는 장소 버튼 가로 스크롤 되도록 수정

### DIFF
--- a/app/feature/curation/components/CurationDetail/organisms/CurationDetailCardList.tsx
+++ b/app/feature/curation/components/CurationDetail/organisms/CurationDetailCardList.tsx
@@ -53,10 +53,7 @@ const CurationDetailCardList = forwardRef<
 
   const handlePlaceScroll = (index: number) => {
     setPlaceIndex(index);
-    placeFilterRefs[index].current?.scrollIntoView({
-      behavior: "auto",
-      inline: "center",
-    });
+    placeFilterRefs[index].current?.scrollIntoView();
   };
 
   useEffect(() => {


### PR DESCRIPTION
큐레이션 상세 스크롤 마다 해당하는 장소 버튼 가로 스크롤 되도록 수정