### PR TITLE
Refactor:큐레이션 상세 페이지 공개/비공개 토글 로직 수정

### DIFF
--- a/app/common/components/ui/buttons/Button/ButtonLock.tsx
+++ b/app/common/components/ui/buttons/Button/ButtonLock.tsx
@@ -16,7 +16,7 @@ export default function ButtonLock({
 
   const toggleLock = () => {
     setIsUnLocked((prevIsLocked) => !prevIsLocked);
-    onClick && onClick(isUnLocked);
+    onClick && onClick(!isUnLocked);
   };
 
   return (

--- a/app/feature/curation/components/CurationMake/organisms/CurationMakeModal.tsx
+++ b/app/feature/curation/components/CurationMake/organisms/CurationMakeModal.tsx
@@ -30,6 +30,7 @@ export default function CurationMakeModal({
     editMode,
     curationInfo
   );
+
   const closeIconClicked = () => {
     if (!editMode) {
       resetCurationMakeData();
@@ -56,11 +57,7 @@ export default function CurationMakeModal({
             </div>
             <div className="w-full pt-[1.6rem] grid justify-items-end">
               <ButtonLock
-                onClick={() =>
-                  handlers.changeCurationOpen(
-                    curationMakeData.open ? false : open
-                  )
-                }
+                onClick={handlers.changeCurationOpen}
                 initialValue={curationMakeData.open}
               />
             </div>

--- a/app/feature/curation/components/MyCuration/molecules/PrivacyToggleButton.tsx
+++ b/app/feature/curation/components/MyCuration/molecules/PrivacyToggleButton.tsx
@@ -2,12 +2,11 @@
 
 import LockIcon from "@/common/assets/icons/lock/LockIcon";
 import UnlockIcon from "@/common/assets/icons/lock/UnlockIcon";
-import useFetching from "@/common/hooks/useFetching";
+import { queryFetchingSelector } from "@/common/state/queryFetching";
 import { toastInfoSelector } from "@/common/state/toast";
 import revalidateCurationDetail from "@/feature/curation/actions/revalidateCurationDetail";
 import revalidatePlaceDetail from "@/feature/place/actions/revalidatePlaceDetail";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
 import { useSetRecoilState } from "recoil";
 
 interface PrivacyToggleButtonProps {
@@ -24,8 +23,7 @@ export default function PrivacyToggleButton({
 
   const setToast = useSetRecoilState(toastInfoSelector);
 
-  const { isFetching, changeFetching } = useFetching();
-  const [show, setShow] = useState(privacy);
+  const setIsQueryFetching = useSetRecoilState(queryFetchingSelector);
 
   const togglePrivacy = async () => {
     const res = await fetch(`/api/curation/privacy/toggle/${id}`);
@@ -33,50 +31,29 @@ export default function PrivacyToggleButton({
     return res.status;
   };
 
-  const revalidateRelatedData = () => {
-    revalidateCurationDetail();
+  const revalidateRelatedData = async () => {
+    await revalidateCurationDetail().then(() => {
+      setIsQueryFetching(false);
+    });
     revalidatePlaceDetail();
     queryClient.invalidateQueries(["getMyCuration"]);
   };
 
   const handleClickTogglePrivacy = async () => {
-    setShow((prev) => !prev);
-    privacy
-      ? setToast({
-          open: true,
-          text: "비공개로 변경되었습니다",
-        })
-      : setToast({
-          open: true,
-          text: "공개로 변경되었습니다",
-        });
+    setIsQueryFetching(true);
+    if ((await togglePrivacy()) === 200) {
+      privacy
+        ? setToast({
+            open: true,
+            text: "비공개로 변경되었습니다",
+          })
+        : setToast({
+            open: true,
+            text: "공개로 변경되었습니다",
+          });
+      revalidateRelatedData();
+    }
   };
-
-  useEffect(() => {
-    const timer = setTimeout(async () => {
-      if (privacy === show) return;
-      if (isFetching) {
-        alert("이전 요청을 처리중입니다");
-        return;
-      } else {
-        changeFetching(true);
-        if ((await togglePrivacy()) === 200) {
-          changeFetching(false);
-          revalidateRelatedData();
-        }
-      }
-    }, 300);
-
-    return () => {
-      clearTimeout(timer);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [show]);
-
-  useEffect(() => {
-    if (privacy) setShow(true);
-    else setShow(false);
-  }, [privacy]);
 
   return (
     <>
@@ -84,8 +61,8 @@ export default function PrivacyToggleButton({
         className="flex items-center gap-[0.4rem] body3-medium text-text-gray-8"
         onClick={handleClickTogglePrivacy}
       >
-        {show ? <UnlockIcon /> : <LockIcon />}
-        {show ? "공개" : "비공개"}
+        {privacy ? <UnlockIcon /> : <LockIcon />}
+        {privacy ? "공개" : "비공개"}
       </div>
     </>
   );


### PR DESCRIPTION
Refactor:큐레이션 상세 페이지 공개/비공개 토글 로직 수정

큐레이션 상세 페이지 배너에서 토글 후 바로 큐레이션 편집 모달 들어갈 시 반영이 안되어있는 버그 -> 큐레이션 상세 데이터가 revalidate 된 후에 queryFetching을 false 로 전환함으로써 데이터가 변경되었음을 보장